### PR TITLE
Hotfix: Fix compilation failure due to optional expiryDate 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The promotional rules:
 The steps to run this program:
 1. `cd` into the project directory
 1. `yarn install`
-1. `npm build`
+1. `yarn build`
 1. `node ./build/main/app.js`
 
 Example usage:

--- a/src/main/converter/PromotionalRuleToTypeConverter.ts
+++ b/src/main/converter/PromotionalRuleToTypeConverter.ts
@@ -9,7 +9,7 @@ export default class PromotionalRuleToTypeConverter
       ...v,
 
       startDate: new Date(v.startDate),
-      expiryDate: new Date(v.expiryDate)
+      ...(v.expiryDate ? { expiryDate: v.expiryDate } : {})
     } as PromotionalRule
   }
 }


### PR DESCRIPTION
- Add expiryDate property in PromotionalRuleToTypeConverter#transform if its available
- Changed README so it recommends using 'yarn build' over 'npm run-script build'